### PR TITLE
Update vedeu to 0.1.17 to fix crash

### DIFF
--- a/playa.gemspec
+++ b/playa.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'playa'
-  spec.version       = '0.0.13'
+  spec.version       = '0.0.13.1'
   spec.authors       = ['Gavin Laking']
   spec.email         = ['gavinlaking@gmail.com']
   spec.summary       = 'Plays mp3s from a directory.'
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'audite',       '0.3.0'
   spec.add_dependency 'ruby-mp3info', '0.8.4'
-  spec.add_dependency 'vedeu',        '0.1.16'
+  spec.add_dependency 'vedeu',        '0.1.17'
 end

--- a/playa.gemspec
+++ b/playa.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'playa'
-  spec.version       = '0.0.13.1'
+  spec.version       = '0.0.14'
   spec.authors       = ['Gavin Laking']
   spec.email         = ['gavinlaking@gmail.com']
   spec.summary       = 'Plays mp3s from a directory.'


### PR DESCRIPTION
Fixes crash with 0.1.16:
Issue: #17

```
$ playa
$HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/vedeu-0.1.16/lib/vedeu/support/groups.rb:48:in `block in in_memory': uninitialized constant Vedeu::Groups::Set (NameError)
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/vedeu-0.1.16/lib/vedeu/support/groups.rb:27:in `yield'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/vedeu-0.1.16/lib/vedeu/support/groups.rb:27:in `add'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/vedeu-0.1.16/lib/vedeu/support/buffers.rb:11:in `create'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/vedeu-0.1.16/lib/vedeu/api/interface.rb:22:in `define'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/vedeu-0.1.16/lib/vedeu/api/interface.rb:10:in `define'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/vedeu-0.1.16/lib/vedeu/api/api.rb:87:in `interface'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/playa-0.0.13/lib/playa/application.rb:5:in `<class:Application>'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/playa-0.0.13/lib/playa/application.rb:2:in `<module:Playa>'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/playa-0.0.13/lib/playa/application.rb:1:in `<top (required)>'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:53:in `require'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:53:in `require'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/playa-0.0.13/lib/playa.rb:19:in `<top (required)>'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:53:in `require'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:53:in `require'
    from $HOME/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/playa-0.0.13/bin/playa:9:in `<top (required)>'
    from $HOME/.rbenv/versions/2.0.0-p353/bin/playa:23:in `load'
    from $HOME/.rbenv/versions/2.0.0-p353/bin/playa:23:in `<main>'
```
